### PR TITLE
Fix save logic to avoid duplication

### DIFF
--- a/fabula_charsheet/pages/controller.py
+++ b/fabula_charsheet/pages/controller.py
@@ -315,6 +315,8 @@ class CharacterController:
         self.character.inventory.backpack.remove_item(item)
 
     def dump_character(self):
+        for old_file in SAVED_CHARS_DIRECTORY.glob(f"*.{self.character.id}.character.yaml"):
+            old_file.unlink()
         with Path(
                 SAVED_CHARS_DIRECTORY,
                 f"{self.character.name}.{self.character.id}.character.yaml"
@@ -329,6 +331,8 @@ class CharacterController:
 
     def dump_avatar(self, image: UploadedFile | None ):
         if image is not None:
+            for old_file in SAVED_CHARS_IMG_DIRECTORY.glob(f"*{self.character.id}.*"):
+                old_file.unlink()
             image_file_path = Path(
                     SAVED_CHARS_IMG_DIRECTORY,
                     f"{self.character.name}.{self.character.id}{Path(image.name).suffix}"

--- a/fabula_charsheet/pages/utils/loader_page_actions.py
+++ b/fabula_charsheet/pages/utils/loader_page_actions.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import streamlit as st
 
 import config
@@ -20,13 +18,14 @@ def delete_character(character: Character, loc: LocNamespace):
                     icon="💀"
                 ):
             s.SAVED_CHARS.char_list.remove(character)
-            char_path = Path(config.SAVED_CHARS_DIRECTORY, f"{character.name}.{character.id}.character.yaml")
-            try:
-                char_path.unlink()
-            except FileNotFoundError:
+            char_paths = list(config.SAVED_CHARS_DIRECTORY.glob(f"*.{character.id}.character.yaml"))
+            if not char_paths:
                 st.error(loc.page_delete_character_file_missing, icon="📜")
-            except PermissionError:
-                st.error(loc.page_delete_character_file_permission, icon="🔒")
+            for char_path in char_paths:
+                try:
+                    char_path.unlink()
+                except PermissionError:
+                    st.error(loc.page_delete_character_file_permission, icon="🔒")
             avatar_path = get_avatar_path(character.id)
             if avatar_path:
                 try:


### PR DESCRIPTION
## Summary

  Fixes `streamlit.errors.StreamlitDuplicateElementKey` on the "Load Character" screen (closes #60 ), caused when two saved characters end up with the same `id`.

  **Root cause:** `dump_character()` writes saves to `{name}.{id}.character.yaml`. If a character is renamed and saved again, this produces a *new* file under the new name — the old file (old name, same `id`) is never deleted. `SavedChars.init()` globs every `*.yaml` in the characters directory, so both files get loaded as separate `Character` objects sharing the same `id`, and the load
  button's `key=f"{char.id}-loader"` collides.

  `dump_avatar()` has the identical pattern (`{name}.{id}{ext}`), which doesn't crash but can silently show a stale avatar via `get_avatar_path()`'s `matches[0]`.

  ## Changes

  - `dump_character()` — deletes any existing `*.{id}.character.yaml` before writing, so a given character `id` only ever maps to one file on disk, even after renames.
  - `dump_avatar()` — same cleanup for avatar images, for the same reason.
  - `delete_character()` — deletes by globbing on `id` instead of reconstructing the exact `{name}.{id}` filename, so it stays correct even for pre-existing stale duplicates, and works regardless of   
  whether `character.name` matches the on-disk filename.

  Fix proposed in issue (#60) appends an `enumerate()` index to the widget keys, which stops the crash but leaves the duplicate file on disk — renamed characters would keep showing a stale "ghost" duplicate in the load list indefinitely, and deleting one entry wouldn't remove the other. Fixing it at the save layer removes the duplicate `id`s at the source, so the load list can't have collisions in the first place.