### PR TITLE
Tests coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run Unit Tests
+
+on:
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Step 1: Clone the repository
+    - name: Check out repository code
+      uses: actions/checkout@v4
+
+    # Step 2: Install uv and set up Python automatically
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: "latest"
+        enable-cache: true # Caches your dependencies so subsequent PR runs are even faster
+
+    # Step 3: Run your tests using uv
+    - name: Run tests
+      run: |
+        uv run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.13"
 
     steps:
     # Step 1: Clone the repository
@@ -18,6 +20,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         version: "latest"
+        python-version: "3.13" # pinned: newer Pythons can outpace pyarrow's prebuilt wheels, forcing a from-source build
         enable-cache: true # Caches your dependencies so subsequent PR runs are even faster
 
     # Step 3: Run your tests using uv

--- a/fabula_charsheet/pages/controller.py
+++ b/fabula_charsheet/pages/controller.py
@@ -306,15 +306,10 @@ class CharacterController:
         self.character.inventory.backpack.add_item(item)
 
     def remove_item(self, item: Item):
-        if item in self.equipped_items():
-            if isinstance(item, Weapon):
-                self.unequip_item("weapon")
-            elif isinstance(item, Armor):
-                self.unequip_item("armor")
-            elif isinstance(item, Shield):
-                self.unequip_item("shield")
-            elif isinstance(item, Accessory):
-                self.unequip_item("accessory")
+        equipped = self.character.inventory.equipped
+        for category in ("main_hand", "off_hand", "armor", "accessory"):
+            if getattr(equipped, category) == item:
+                setattr(equipped, category, None)
         self.character.inventory.backpack.remove_item(item)
 
     def dump_character(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,4 +142,7 @@ def assets_dir(tmp_path: Path) -> Path:
     (special / 'dances.yaml').write_text('[]')
     (special / 'therioforms.yaml').write_text('[]')
 
+    qualities = tmp_path / 'qualities'
+    qualities.mkdir()
+
     return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ PKG = ROOT / 'fabula_charsheet'
 if str(PKG) not in sys.path:
     sys.path.insert(0, str(PKG))
 
-# Stub streamlit module
+# Stub streamlit module (pages/controller.py and most model code never touch it;
+# only data/localizator.py and UI code do, via st.session_state).
 class SessionState(dict):
     __getattr__ = dict.get
     __setattr__ = dict.__setitem__
@@ -20,53 +21,9 @@ class SessionState(dict):
 st_stub = types.SimpleNamespace(session_state=SessionState())
 sys.modules.setdefault('streamlit', st_stub)
 
-# Stub yaml module using json
-yaml_stub = types.SimpleNamespace()
-
-def _yaml_load(stream, Loader=None):
-    return json.load(stream)
-
-yaml_stub.load = _yaml_load
-yaml_stub.SafeLoader = yaml_stub.UnsafeLoader = yaml_stub.Loader = object
-sys.modules.setdefault('yaml', yaml_stub)
-
-# Stub pydantic module
-pydantic_stub = types.SimpleNamespace()
-
-class BaseModel:
-    def __init__(self, **data):
-        for k, v in data.items():
-            setattr(self, k, v)
-
-def Field(*, default=None, default_factory=None):
-    if default_factory is not None:
-        return default_factory()
-    return default
-
-class RootModel(BaseModel):
-    def __init__(self, root=None):
-        super().__init__()
-        self.root = root
-
-    def __class_getitem__(cls, item):
-        return cls
-
-class ConfigDict(dict):
-    pass
-
-def conint(**kwargs):
-    return int
-
-pydantic_stub.BaseModel = BaseModel
-pydantic_stub.Field = Field
-pydantic_stub.RootModel = RootModel
-pydantic_stub.ConfigDict = ConfigDict
-pydantic_stub.conint = conint
-sys.modules.setdefault('pydantic', pydantic_stub)
-
-# Stub annotated_types
-annotated_stub = types.SimpleNamespace(Len=lambda *args, **kwargs: None)
-sys.modules.setdefault('annotated_types', annotated_stub)
+# yaml, pydantic and annotated_types are used for real (not stubbed) so that
+# model validation, per-instance default_factory behavior, and enum/type
+# coercion match production exactly.
 
 @pytest.fixture(scope='session')
 def streamlit_stub():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,3 +103,20 @@ def assets_dir(tmp_path: Path) -> Path:
     qualities.mkdir()
 
     return tmp_path
+
+
+@pytest.fixture
+def loc():
+    from data.models import LocNamespace
+    return LocNamespace(root={
+        "dice_prefix": "d",
+        "error_class_not_found": "Class {class_name} not found.",
+        "error_unexpected_class_type": "Unexpected class type: {class_type}",
+        "error_equipping_item": "Cannot equip this item.",
+    })
+
+
+@pytest.fixture
+def controller(loc):
+    from pages.controller import CharacterController
+    return CharacterController(loc)

--- a/tests/test_char_class.py
+++ b/tests/test_char_class.py
@@ -1,5 +1,5 @@
-from fabula_charsheet.data import compendium
-from fabula_charsheet.data.models.skill import Skill
+from data import compendium
+from data.models.skill import Skill
 
 
 def _get_class(name, assets_dir):

--- a/tests/test_character.py
+++ b/tests/test_character.py
@@ -1,11 +1,11 @@
 import pytest
 import json
 
-from fabula_charsheet.data.models import Character, HeroicSkill, HeroicSkillName
-from fabula_charsheet.data.models.character import InvalidCharacterField
-from fabula_charsheet.data import compendium
-from fabula_charsheet.data.localizator import init_localizator
-from fabula_charsheet.data.models import LangEnum
+from data.models import Character, HeroicSkill, HeroicSkillName
+from data.models.character import InvalidCharacterField
+from data import compendium
+from data.localizator import init_localizator
+from data.models import LangEnum
 
 
 def _setup_loc(streamlit_stub, tmp_path):
@@ -52,7 +52,7 @@ def test_character_utility_methods(assets_dir, streamlit_stub, tmp_path):
     compendium.COMPENDIUM = None
     compendium.init(assets_dir)
     c = compendium.COMPENDIUM
-    from fabula_charsheet.data.models.skill import Skill
+    from data.models.skill import Skill
     for cls in c.classes.classes:
         cls.skills = [Skill(**s) if isinstance(s, dict) else s for s in cls.skills]
     char = Character()

--- a/tests/test_compendium.py
+++ b/tests/test_compendium.py
@@ -1,4 +1,4 @@
-from fabula_charsheet.data import compendium
+from data import compendium
 
 
 def test_compendium_initialization(assets_dir):
@@ -15,7 +15,7 @@ def test_compendium_retrieval_methods(assets_dir):
     compendium.COMPENDIUM = None
     compendium.init(assets_dir)
     c = compendium.COMPENDIUM
-    from fabula_charsheet.data.models.skill import Skill
+    from data.models.skill import Skill
     for cls in c.classes.classes:
         cls.skills = [Skill(**s) if isinstance(s, dict) else s for s in cls.skills]
     arcanist = c.classes.get_class('arcanist')

--- a/tests/test_controller_companion.py
+++ b/tests/test_controller_companion.py
@@ -1,0 +1,200 @@
+import math
+
+from data.models import (
+    AttributeName,
+    CharClass,
+    ClassName,
+    Companion,
+    CompanionSkill,
+    CompanionSkillName,
+    DamageType,
+    HeroicSkill,
+    HeroicSkillName,
+    Skill,
+    Species,
+    Status,
+)
+
+
+def with_faithful_companion(controller, level, companion, heroic_skills=None):
+    controller.character.classes = [
+        CharClass(name=ClassName.wayfarer, skills=[Skill(name="faithful_companion", current_level=level, max_level=10)])
+    ]
+    controller.character.special.companion = companion
+    if heroic_skills:
+        controller.character.heroic_skills = heroic_skills
+
+
+# --- companion_skill_level / max_hp / crisis / current_hp ---
+
+def test_companion_skill_level_defaults_to_zero_without_skill(controller):
+    assert controller.companion_skill_level() == 0
+
+
+def test_companion_max_hp_base_formula(controller):
+    controller.character.level = 10
+    companion = Companion(might=5)
+    with_faithful_companion(controller, level=3, companion=companion)
+    expected = 3 * 5 + math.floor(10 / 2)
+    assert controller.companion_max_hp() == expected
+
+
+def test_companion_max_hp_improved_hit_points_and_heroic_bonus(controller):
+    controller.character.level = 10
+    companion = Companion(might=5, skills=[
+        CompanionSkill(name=CompanionSkillName.improved_hit_points),
+        CompanionSkill(name=CompanionSkillName.improved_hit_points),
+    ])
+    with_faithful_companion(
+        controller, level=3, companion=companion,
+        heroic_skills=[HeroicSkill(name=HeroicSkillName.heroic_companion)],
+    )
+    expected = 3 * 5 + math.floor(10 / 2) + 10 * 2 + 10
+    assert controller.companion_max_hp() == expected
+
+
+def test_companion_crisis_value_and_current_hp(controller):
+    controller.character.level = 10
+    companion = Companion(might=5)
+    with_faithful_companion(controller, level=3, companion=companion)
+    max_hp = controller.companion_max_hp()
+    assert controller.companion_crisis_value() == math.floor(max_hp / 2)
+    controller.state.companion_minus_hp = max_hp + 10
+    assert controller.companion_current_hp() == 0  # clamped at 0
+
+
+# --- defense / magic defense ---
+
+def test_companion_defense_with_improved_defenses_defense_option(controller):
+    companion = Companion(dexterity=9, skills=[
+        CompanionSkill(name=CompanionSkillName.improved_defenses, defense_option="defense")
+    ])
+    controller.character.special.companion = companion
+    assert controller.companion_defense() == 9 + 2
+    assert controller.companion_magic_defense() == companion.insight + 1
+
+
+def test_companion_defense_with_improved_defenses_magic_defense_option(controller):
+    companion = Companion(dexterity=9, insight=7, skills=[
+        CompanionSkill(name=CompanionSkillName.improved_defenses, defense_option="magic_defense")
+    ])
+    controller.character.special.companion = companion
+    assert controller.companion_defense() == 9 + 1
+    assert controller.companion_magic_defense() == 7 + 2
+
+
+# --- check bonus / attack damage bonus ---
+
+def test_companion_check_bonus_matches_skill_level(controller):
+    with_faithful_companion(controller, level=4, companion=Companion())
+    assert controller.companion_check_bonus() == 4
+
+
+def test_companion_attack_damage_bonus_matches_attack_index(controller):
+    companion = Companion(skills=[
+        CompanionSkill(name=CompanionSkillName.improved_damage, attack_index=0),
+        CompanionSkill(name=CompanionSkillName.improved_damage, attack_index=0),
+        CompanionSkill(name=CompanionSkillName.improved_damage, attack_index=1),
+    ])
+    controller.character.special.companion = companion
+    assert controller.companion_attack_damage_bonus(0) == 10
+    assert controller.companion_attack_damage_bonus(1) == 5
+    assert controller.companion_attack_damage_bonus(2) == 0
+
+
+# --- resistances / immunities / absorptions / vulnerabilities ---
+
+def test_companion_all_resistances_combines_innate_and_skill(controller):
+    companion = Companion(species=Species.construct, skills=[
+        CompanionSkill(name=CompanionSkillName.damage_resistance, damage_types=[DamageType.fire])
+    ])
+    controller.character.special.companion = companion
+    resistances = controller.companion_all_resistances()
+    assert DamageType.earth in resistances  # innate for construct
+    assert DamageType.fire in resistances
+
+
+def test_companion_all_immunities_combines_innate_and_skill(controller):
+    companion = Companion(species=Species.construct, skills=[
+        CompanionSkill(name=CompanionSkillName.damage_immunity, damage_types=[DamageType.ice])
+    ])
+    controller.character.special.companion = companion
+    immunities = controller.companion_all_immunities()
+    assert DamageType.poison in immunities  # innate for construct
+    assert DamageType.ice in immunities
+
+
+def test_companion_all_absorptions_only_from_skills(controller):
+    companion = Companion(skills=[
+        CompanionSkill(name=CompanionSkillName.damage_absorption, damage_types=[DamageType.dark]),
+    ])
+    controller.character.special.companion = companion
+    assert controller.companion_all_absorptions() == [DamageType.dark]
+
+
+def test_companion_all_vulnerabilities_from_species_choice(controller):
+    companion = Companion(species=Species.plant, species_damage_choice=DamageType.fire)
+    controller.character.special.companion = companion
+    assert controller.companion_all_vulnerabilities() == [DamageType.fire]
+
+
+def test_companion_all_status_immunities_combines_innate_and_skill(controller):
+    companion = Companion(species=Species.plant, skills=[
+        CompanionSkill(name=CompanionSkillName.status_effect_immunity, statuses=[Status.poisoned]),
+    ])
+    controller.character.special.companion = companion
+    immunities = controller.companion_all_status_immunities()
+    assert Status.dazed in immunities  # innate for plant
+    assert Status.poisoned in immunities
+
+
+# --- max skills / heroic companion attribute bonus ---
+
+def test_companion_max_skills_by_species_and_heroic_bonus(controller):
+    controller.character.level = 10
+    companion = Companion(species=Species.beast)
+    controller.character.special.companion = companion
+    assert controller.companion_max_skills() == 4
+
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.heroic_companion)]
+    assert controller.companion_max_skills() == 5
+
+    controller.character.level = 40
+    assert controller.companion_max_skills() == 6
+
+
+def test_companion_max_skills_without_companion_is_zero(controller):
+    controller.character.special.companion = None
+    assert controller.companion_max_skills() == 0
+
+
+def test_apply_heroic_companion_attribute_increments_and_clamps(controller):
+    companion = Companion(might=11)
+    controller.character.special.companion = companion
+    controller.apply_heroic_companion_attribute(AttributeName.might)
+    assert companion.might == 12  # 11 + 2 clamped at MAX_ATTRIBUTE_VALUE
+
+
+# --- set_companion / remove_companion / companion_flee ---
+
+def test_set_companion_resets_companion_hp_state(controller):
+    controller.state.companion_minus_hp = 20
+    controller.set_companion(Companion(name="fido"))
+    assert controller.character.special.companion.name == "fido"
+    assert controller.state.companion_minus_hp == 0
+
+
+def test_remove_companion_clears_companion_and_hp_state(controller):
+    controller.set_companion(Companion(name="fido"))
+    controller.state.companion_minus_hp = 5
+    controller.remove_companion()
+    assert controller.character.special.companion is None
+    assert controller.state.companion_minus_hp == 0
+
+
+def test_companion_flee_sets_hp_to_crisis_value(controller):
+    controller.character.level = 10
+    companion = Companion(might=5)
+    with_faithful_companion(controller, level=3, companion=companion)
+    controller.companion_flee()
+    assert controller.state.companion_minus_hp == controller.companion_max_hp() - controller.companion_crisis_value()

--- a/tests/test_controller_defense.py
+++ b/tests/test_controller_defense.py
@@ -1,0 +1,81 @@
+import math
+
+from data.models import AttributeName, Accessory, Armor, CharClass, ClassName, Skill, Therioform
+
+
+def test_defense_no_armor_uses_dexterity(controller):
+    controller.character.dexterity.current = 9
+    assert controller.defense() == 9
+
+
+def test_defense_sums_equipped_item_bonuses(controller):
+    controller.character.dexterity.current = 9
+    controller.character.inventory.equipped.accessory = Accessory(name="ring", bonus_defense=2)
+    assert controller.defense() == 11
+
+
+def test_defense_armor_with_flat_int_defense(controller):
+    controller.character.dexterity.current = 9
+    controller.character.inventory.equipped.armor = Armor(name="plate", defense=10, bonus_defense=1)
+    assert controller.defense() == 10 + 1
+
+
+def test_defense_armor_with_attribute_based_defense(controller):
+    controller.character.dexterity.current = 11
+    controller.character.inventory.equipped.armor = Armor(name="robe", defense=AttributeName.dexterity)
+    assert controller.defense() == 11
+
+
+def test_defense_rogue_dodge_bonus(controller):
+    controller.character.dexterity.current = 8
+    controller.character.classes = [
+        CharClass(name=ClassName.rogue, skills=[Skill(name="dodge", current_level=3, max_level=5)])
+    ]
+    assert controller.defense() == 8 + 3
+
+
+def test_defense_placophora_overrides_when_higher(controller):
+    controller.character.dexterity.current = 8
+    controller.character.classes = [
+        CharClass(name=ClassName.mutant, skills=[Skill(name="theriomorphosis", current_level=4, max_level=10)])
+    ]
+    controller.state.active_therioforms = [Therioform(name="placophora")]
+    expected = 13 + math.floor(4 / 2)
+    assert controller.defense() == expected
+
+
+def test_defense_placophora_does_not_lower_higher_defense(controller):
+    controller.character.dexterity.current = 8
+    controller.character.inventory.equipped.armor = Armor(name="plate", defense=20)
+    controller.character.classes = [
+        CharClass(name=ClassName.mutant, skills=[Skill(name="theriomorphosis", current_level=4, max_level=10)])
+    ]
+    controller.state.active_therioforms = [Therioform(name="placophora")]
+    assert controller.defense() == 20
+
+
+def test_magic_defense_uses_insight_and_item_bonuses(controller):
+    controller.character.insight.current = 7
+    controller.character.inventory.equipped.accessory = Accessory(name="amulet", bonus_magic_defense=3)
+    assert controller.magic_defense() == 10
+
+
+def test_initiative_with_no_bonus(controller, loc):
+    controller.character.insight.current = 8
+    controller.character.dexterity.current = 9
+    assert controller.initiative() == "d8 + d9"
+
+
+def test_initiative_with_positive_bonus(controller):
+    controller.character.insight.current = 8
+    controller.character.dexterity.current = 9
+    controller.character.inventory.equipped.accessory = Accessory(name="boots", bonus_initiative=4)
+    assert controller.initiative() == "d8 + d9 +4"
+
+
+def test_initiative_with_negative_bonus(controller):
+    controller.character.insight.current = 8
+    controller.character.dexterity.current = 9
+    controller.character.inventory.equipped.main_hand = None
+    controller.character.inventory.equipped.accessory = Accessory(name="cursed_ring", bonus_initiative=-3)
+    assert controller.initiative() == "d8 + d9 -3"

--- a/tests/test_controller_equipment.py
+++ b/tests/test_controller_equipment.py
@@ -1,0 +1,235 @@
+from data.models import (
+    Accessory,
+    Armor,
+    CharClass,
+    ClassName,
+    GripType,
+    HeroicSkill,
+    HeroicSkillName,
+    Shield,
+    Skill,
+    Weapon,
+    WeaponRange,
+)
+
+
+def one_handed(name="sword", **kwargs):
+    return Weapon(name=name, grip_type=GripType.one_handed, **kwargs)
+
+
+def two_handed(name="greatsword", **kwargs):
+    return Weapon(name=name, grip_type=GripType.two_handed, **kwargs)
+
+
+# --- can_equip_martial ---
+
+def test_can_equip_martial_non_martial_item_always_true(controller):
+    assert controller.can_equip_martial(Weapon(name="dagger", martial=False)) is True
+
+
+def test_can_equip_martial_weapon_requires_class_support(controller):
+    weapon = Weapon(name="bow", martial=True, range=WeaponRange.ranged)
+    assert controller.can_equip_martial(weapon) is False
+    controller.character.classes = [CharClass(name=ClassName.sharpshooter, martial_ranged=True)]
+    assert controller.can_equip_martial(weapon) is True
+
+
+def test_can_equip_martial_armor_requires_class_support(controller):
+    armor = Armor(name="plate", martial=True)
+    assert controller.can_equip_martial(armor) is False
+    controller.character.classes = [CharClass(name=ClassName.guardian, martial_armor=True)]
+    assert controller.can_equip_martial(armor) is True
+
+
+def test_can_equip_martial_shield_requires_class_support(controller):
+    shield = Shield(name="tower_shield", martial=True)
+    assert controller.can_equip_martial(shield) is False
+    controller.character.classes = [CharClass(name=ClassName.guardian, martial_shields=True)]
+    assert controller.can_equip_martial(shield) is True
+
+
+# --- equip_item: armor / accessory ---
+
+def test_equip_armor_replaces_current_armor(controller):
+    controller.equip_item(Armor(name="robe"))
+    controller.equip_item(Armor(name="plate"))
+    assert controller.character.inventory.equipped.armor.name == "plate"
+
+
+def test_equip_accessory_replaces_current_accessory(controller):
+    controller.equip_item(Accessory(name="ring"))
+    controller.equip_item(Accessory(name="amulet"))
+    assert controller.character.inventory.equipped.accessory.name == "amulet"
+
+
+# --- equip_item: weapons ---
+
+def test_equip_two_handed_weapon_without_monkey_grip_clears_both_hands(controller):
+    equipped = controller.character.inventory.equipped
+    equipped.main_hand = one_handed("dagger")
+    equipped.off_hand = one_handed("dagger2")
+    controller.equip_item(two_handed("greatsword"))
+    assert equipped.main_hand.name == "greatsword"
+    assert equipped.off_hand is None
+
+
+def test_equip_one_handed_weapon_into_empty_main_hand(controller):
+    controller.equip_item(one_handed("sword"))
+    assert controller.character.inventory.equipped.main_hand.name == "sword"
+
+
+def test_equip_one_handed_weapon_dual_wields_into_off_hand(controller):
+    controller.equip_item(one_handed("sword"))
+    controller.equip_item(one_handed("dagger"))
+    equipped = controller.character.inventory.equipped
+    assert equipped.main_hand.name == "sword"
+    assert equipped.off_hand.name == "dagger"
+
+
+def test_equip_one_handed_weapon_replaces_main_hand_when_incompatible(controller):
+    equipped = controller.character.inventory.equipped
+    equipped.main_hand = two_handed("greatsword")
+    controller.equip_item(one_handed("dagger"))
+    assert equipped.main_hand.name == "dagger"
+    assert equipped.off_hand is None
+
+
+def test_equip_weapon_replaces_main_hand_when_both_hands_full(controller):
+    equipped = controller.character.inventory.equipped
+    equipped.main_hand = one_handed("sword")
+    equipped.off_hand = one_handed("dagger")
+    controller.equip_item(one_handed("axe"))
+    assert equipped.main_hand.name == "axe"
+    assert equipped.off_hand.name == "dagger"
+
+
+def test_equip_two_handed_weapons_dual_wielded_with_monkey_grip(controller):
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.monkey_grip)]
+    controller.equip_item(two_handed("greatsword_a"))
+    controller.equip_item(two_handed("greatsword_b"))
+    equipped = controller.character.inventory.equipped
+    assert equipped.main_hand.name == "greatsword_a"
+    assert equipped.off_hand.name == "greatsword_b"
+
+
+# --- equip_item: shields ---
+
+def test_equip_shield_normal_case_clears_two_handed_main_hand(controller):
+    equipped = controller.character.inventory.equipped
+    equipped.main_hand = two_handed("greatsword")
+    controller.equip_item(Shield(name="buckler"))
+    assert equipped.main_hand is None
+    assert equipped.off_hand.name == "buckler"
+
+
+def test_equip_shield_normal_case_keeps_one_handed_main_hand(controller):
+    equipped = controller.character.inventory.equipped
+    equipped.main_hand = one_handed("sword")
+    controller.equip_item(Shield(name="buckler"))
+    assert equipped.main_hand.name == "sword"
+    assert equipped.off_hand.name == "buckler"
+
+
+def test_equip_shield_with_monkey_grip_does_not_clear_main_hand(controller):
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.monkey_grip)]
+    equipped = controller.character.inventory.equipped
+    equipped.main_hand = two_handed("greatsword")
+    controller.equip_item(Shield(name="buckler"))
+    assert equipped.main_hand.name == "greatsword"
+    assert equipped.off_hand.name == "buckler"
+
+
+def test_equip_shield_with_dual_shieldbearer_into_empty_off_hand(controller):
+    controller.character.classes = [
+        CharClass(name=ClassName.guardian, skills=[Skill(name="dual_shieldbearer", current_level=1, max_level=1)])
+    ]
+    controller.equip_item(Shield(name="buckler"))
+    assert controller.character.inventory.equipped.off_hand.name == "buckler"
+
+
+def test_equip_shield_with_dual_shieldbearer_merges_into_twin_shields(controller):
+    controller.character.classes = [
+        CharClass(name=ClassName.guardian, skills=[Skill(name="dual_shieldbearer", current_level=1, max_level=1)])
+    ]
+    equipped = controller.character.inventory.equipped
+    equipped.off_hand = Shield(name="buckler", bonus_defense=1, bonus_magic_defense=1)
+    controller.equip_item(Shield(name="tower_shield", cost=50, bonus_defense=2, bonus_magic_defense=3))
+    assert equipped.main_hand.name == "twin_shields"
+    assert equipped.main_hand.bonus_defense == 2
+    assert equipped.main_hand.bonus_magic_defense == 3
+    assert equipped.main_hand.bonus_damage == 5
+    # the previously equipped shield is left untouched in the off hand
+    assert equipped.off_hand.name == "buckler"
+
+
+def test_equip_shield_with_dual_shieldbearer_replaces_non_shield_off_hand(controller):
+    controller.character.classes = [
+        CharClass(name=ClassName.guardian, skills=[Skill(name="dual_shieldbearer", current_level=1, max_level=1)])
+    ]
+    equipped = controller.character.inventory.equipped
+    equipped.off_hand = one_handed("dagger")
+    controller.equip_item(Shield(name="buckler"))
+    assert equipped.off_hand.name == "buckler"
+
+
+# --- unequip_item / equipped_items ---
+
+def test_unequip_item_clears_valid_category(controller):
+    controller.character.inventory.equipped.armor = Armor(name="plate")
+    controller.unequip_item("armor")
+    assert controller.character.inventory.equipped.armor is None
+
+
+def test_unequip_item_ignores_unknown_category(controller):
+    controller.character.inventory.equipped.armor = Armor(name="plate")
+    controller.unequip_item("weapon")  # not a real Equipped field
+    assert controller.character.inventory.equipped.armor is not None
+
+
+def test_equipped_items_lists_only_non_none_slots(controller):
+    equipped = controller.character.inventory.equipped
+    equipped.main_hand = one_handed("sword")
+    equipped.armor = Armor(name="plate")
+    items = controller.equipped_items()
+    assert {i.name for i in items} == {"sword", "plate"}
+
+
+# --- remove_item ---
+
+def test_remove_item_unequips_weapon_from_main_hand_and_removes_from_backpack(controller):
+    weapon = one_handed("sword")
+    controller.add_item(weapon)
+    controller.equip_item(weapon)
+    controller.remove_item(weapon)
+    assert controller.character.inventory.equipped.main_hand is None
+    assert weapon not in controller.character.inventory.backpack.weapons
+
+
+def test_remove_item_unequips_shield_from_off_hand_and_removes_from_backpack(controller):
+    shield = Shield(name="buckler")
+    controller.add_item(shield)
+    controller.equip_item(shield)
+    controller.remove_item(shield)
+    assert controller.character.inventory.equipped.off_hand is None
+    assert shield not in controller.character.inventory.backpack.shields
+
+
+def test_remove_item_unequips_armor_and_accessory(controller):
+    armor = Armor(name="plate")
+    accessory = Accessory(name="ring")
+    controller.add_item(armor)
+    controller.add_item(accessory)
+    controller.equip_item(armor)
+    controller.equip_item(accessory)
+    controller.remove_item(armor)
+    controller.remove_item(accessory)
+    equipped = controller.character.inventory.equipped
+    assert equipped.armor is None
+    assert equipped.accessory is None
+
+
+def test_remove_item_not_equipped_only_removes_from_backpack(controller):
+    weapon = one_handed("spare_dagger")
+    controller.add_item(weapon)
+    controller.remove_item(weapon)
+    assert weapon not in controller.character.inventory.backpack.weapons

--- a/tests/test_controller_persistence.py
+++ b/tests/test_controller_persistence.py
@@ -1,0 +1,99 @@
+import types
+
+import pytest
+import yaml
+
+from data.models import Character
+
+
+@pytest.fixture(autouse=True)
+def isolated_save_directories(monkeypatch, tmp_path):
+    chars_dir = tmp_path / "characters"
+    img_dir = tmp_path / "characters" / "character_images"
+    states_dir = tmp_path / "characters" / "states"
+    chars_dir.mkdir(parents=True)
+    img_dir.mkdir(parents=True)
+    states_dir.mkdir(parents=True)
+    monkeypatch.setattr("pages.controller.SAVED_CHARS_DIRECTORY", chars_dir)
+    monkeypatch.setattr("pages.controller.SAVED_CHARS_IMG_DIRECTORY", img_dir)
+    monkeypatch.setattr("pages.controller.SAVED_STATES_DIRECTORY", states_dir)
+    return types.SimpleNamespace(chars=chars_dir, images=img_dir, states=states_dir)
+
+
+def test_dump_character_writes_expected_file(controller, isolated_save_directories):
+    controller.character.name = "Alice"
+    controller.dump_character()
+    expected = isolated_save_directories.chars / f"Alice.{controller.character.id}.character.yaml"
+    assert expected.exists()
+
+
+def test_dump_character_round_trips_via_yaml(controller, isolated_save_directories):
+    controller.character.name = "Bob"
+    controller.character.level = 12
+    controller.dump_character()
+    saved_path = isolated_save_directories.chars / f"Bob.{controller.character.id}.character.yaml"
+    with saved_path.open(encoding="utf-8") as f:
+        raw = yaml.load(f, Loader=yaml.UnsafeLoader)
+    reloaded = Character(**raw)
+    assert reloaded.name == "Bob"
+    assert reloaded.level == 12
+    assert reloaded.id == controller.character.id
+
+
+def test_dump_character_removes_stale_files_for_same_id(controller, isolated_save_directories):
+    controller.character.name = "Old Name"
+    controller.dump_character()
+    controller.character.name = "New Name"
+    controller.dump_character()
+    matches = list(isolated_save_directories.chars.glob(f"*.{controller.character.id}.character.yaml"))
+    assert len(matches) == 1
+    assert matches[0].name == f"New Name.{controller.character.id}.character.yaml"
+
+
+def test_dump_state_writes_expected_file(controller, isolated_save_directories):
+    controller.state.minus_hp = 7
+    controller.dump_state()
+    expected = isolated_save_directories.states / f"{controller.character.id}.yaml"
+    assert expected.exists()
+
+
+def test_load_state_round_trips(controller, isolated_save_directories):
+    controller.state.minus_hp = 15
+    controller.state.minus_mp = 3
+    controller.dump_state()
+    controller.state.minus_hp = 0
+    controller.state.minus_mp = 0
+    controller.load_state()
+    assert controller.state.minus_hp == 15
+    assert controller.state.minus_mp == 3
+
+
+def test_load_state_missing_file_resets_state_and_raises(controller):
+    controller.state.minus_hp = 99
+    with pytest.raises(Exception):
+        controller.load_state()
+    assert controller.state.minus_hp == 0  # reset to a fresh CharState()
+
+
+def test_dump_avatar_writes_image_bytes(controller, isolated_save_directories):
+    controller.character.name = "Carol"
+    image = types.SimpleNamespace(name="avatar.png", getbuffer=lambda: b"PNGDATA")
+    controller.dump_avatar(image)
+    expected = isolated_save_directories.images / f"Carol.{controller.character.id}.png"
+    assert expected.read_bytes() == b"PNGDATA"
+
+
+def test_dump_avatar_none_is_a_no_op(controller, isolated_save_directories):
+    controller.dump_avatar(None)
+    assert list(isolated_save_directories.images.iterdir()) == []
+
+
+def test_dump_avatar_removes_stale_images_for_same_id(controller, isolated_save_directories):
+    image_a = types.SimpleNamespace(name="a.png", getbuffer=lambda: b"A")
+    image_b = types.SimpleNamespace(name="b.jpg", getbuffer=lambda: b"B")
+    controller.character.name = "Dave"
+    controller.dump_avatar(image_a)
+    controller.dump_avatar(image_b)
+    matches = list(isolated_save_directories.images.glob(f"*{controller.character.id}.*"))
+    assert len(matches) == 1
+    assert matches[0].suffix == ".jpg"

--- a/tests/test_controller_progression.py
+++ b/tests/test_controller_progression.py
@@ -1,0 +1,213 @@
+from data.models import (
+    Accessory,
+    CharClass,
+    ClassName,
+    HeroicSkill,
+    HeroicSkillName,
+    Quality,
+    Skill,
+    Spell,
+)
+
+
+# --- apply_levelup ---
+
+def test_apply_levelup_increments_level_and_levels_up_existing_skill(controller):
+    controller.character.level = 5
+    skill = Skill(name="dodge", current_level=1, max_level=5)
+    controller.character.classes = [CharClass(name=ClassName.rogue, skills=[skill])]
+    controller.apply_levelup(skill, ClassName.rogue, None, [])
+    assert controller.character.level == 6
+    assert controller.character.classes[0].get_skill_level("dodge") == 2
+
+
+def test_apply_levelup_adds_new_class(controller):
+    controller.character.level = 5
+    controller.character.classes = []
+    new_class = CharClass(name=ClassName.guardian)
+    skill = Skill(name="unrelated_skill")
+    controller.apply_levelup(skill, ClassName.guardian, new_class, [])
+    assert controller.character.level == 6
+    assert controller.is_class_added(ClassName.guardian)
+
+
+def test_apply_levelup_sets_spells_when_skill_grants_them(controller):
+    controller.character.level = 5
+    skill = Skill(name="elemental_magic", current_level=1, max_level=10, can_add_spell=True)
+    controller.character.classes = [CharClass(name=ClassName.elementalist, skills=[skill])]
+    spells = [Spell(name="fireball", mp_cost=10)]
+    controller.apply_levelup(skill, ClassName.elementalist, None, spells)
+    assert controller.character.spells[ClassName.elementalist] == spells
+
+
+# --- can_add_heroic_skill ---
+
+def test_can_add_heroic_skill_true_when_mastered_class_without_heroic_skill(controller):
+    skill = Skill(name="s", current_level=10, max_level=10)
+    controller.character.classes = [CharClass(name=ClassName.guardian, skills=[skill])]
+    assert controller.can_add_heroic_skill() is True
+
+
+def test_can_add_heroic_skill_false_when_already_matched(controller):
+    skill = Skill(name="s", current_level=10, max_level=10)
+    controller.character.classes = [CharClass(name=ClassName.guardian, skills=[skill])]
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.extra_hp)]
+    assert controller.can_add_heroic_skill() is False
+
+
+def test_can_add_heroic_skill_false_when_no_mastered_class(controller):
+    skill = Skill(name="s", current_level=5, max_level=10)
+    controller.character.classes = [CharClass(name=ClassName.guardian, skills=[skill])]
+    assert controller.can_add_heroic_skill() is False
+
+
+# --- is_heroic_skill_available ---
+
+def test_is_heroic_skill_available_already_owned_respects_repeatable_flag(controller):
+    skill = HeroicSkill(name=HeroicSkillName.extra_hp, can_add_several_times=False)
+    controller.character.heroic_skills = [skill]
+    assert controller.is_heroic_skill_available(skill) is False
+
+    repeatable = HeroicSkill(name=HeroicSkillName.extra_mp, can_add_several_times=True)
+    controller.character.heroic_skills = [repeatable]
+    assert controller.is_heroic_skill_available(repeatable) is True
+
+
+def test_is_heroic_skill_available_heroic_companion_requires_companion(controller):
+    skill = HeroicSkill(name=HeroicSkillName.heroic_companion)
+    assert controller.is_heroic_skill_available(skill) is False
+
+
+def test_is_heroic_skill_available_no_required_class_is_always_true(controller):
+    skill = HeroicSkill(name=HeroicSkillName.comet)
+    assert controller.is_heroic_skill_available(skill) is True
+
+
+def test_is_heroic_skill_available_requires_mastered_class(controller):
+    skill = HeroicSkill(name=HeroicSkillName.comet, required_class=[ClassName.entropist])
+    assert controller.is_heroic_skill_available(skill) is False
+
+    mastered = Skill(name="s", current_level=10, max_level=10)
+    controller.character.classes = [CharClass(name=ClassName.entropist, skills=[mastered])]
+    assert controller.is_heroic_skill_available(skill) is True
+
+
+def test_is_heroic_skill_available_requires_specific_skill_level(controller):
+    required_skill = Skill(name="dodge")
+    skill = HeroicSkill(
+        name=HeroicSkillName.comet,
+        required_class=[ClassName.rogue],
+        required_skill=required_skill,
+    )
+    mastered = Skill(name="s", current_level=10, max_level=10)
+    dodge_unlearned = Skill(name="dodge", current_level=0, max_level=5)
+    controller.character.classes = [CharClass(name=ClassName.rogue, skills=[mastered, dodge_unlearned])]
+    assert controller.is_heroic_skill_available(skill) is False
+
+    dodge_learned = Skill(name="dodge", current_level=1, max_level=5)
+    mastered_minus_dodge = Skill(name="s", current_level=9, max_level=10)
+    controller.character.classes = [CharClass(name=ClassName.rogue, skills=[mastered_minus_dodge, dodge_learned])]
+    assert controller.is_heroic_skill_available(skill) is True
+
+
+# --- can_add_class / can_increase_attribute / has_enough_skills ---
+
+def test_can_add_class_allows_up_to_two_non_mastered_classes(controller):
+    controller.character.classes = [CharClass(name=ClassName.rogue), CharClass(name=ClassName.guardian)]
+    assert controller.can_add_class() is True
+    controller.character.classes.append(CharClass(name=ClassName.fury))
+    assert controller.can_add_class() is False
+
+
+def test_can_increase_attribute_only_at_thresholds(controller):
+    controller.character.level = 21
+    assert controller.can_increase_attribute() is False
+
+    controller.character.level = 20
+    controller.character.dexterity.base = 8
+    controller.character.might.base = 8
+    controller.character.insight.base = 8
+    controller.character.willpower.base = 8  # sum = 32 < 34
+    assert controller.can_increase_attribute() is True
+
+    controller.character.dexterity.base = 10  # sum = 34, not < 34
+    assert controller.can_increase_attribute() is False
+
+
+def test_has_enough_skills(controller):
+    controller.character.level = 3
+    controller.character.classes = []
+    assert controller.has_enough_skills() is False
+
+    skill = Skill(name="s", current_level=3, max_level=10)
+    controller.character.classes = [CharClass(name=ClassName.guardian, skills=[skill])]
+    assert controller.has_enough_skills() is True
+
+
+def test_can_add_skill_number(controller):
+    controller.character.level = 5
+    skill = Skill(name="s", current_level=2, max_level=10)
+    controller.character.classes = [CharClass(name=ClassName.guardian, skills=[skill])]
+    assert controller.can_add_skill_number() == 3
+
+
+# --- add_heroic_skill / apply_heroic_skill_effect ---
+
+def test_add_heroic_skill_comet_grants_entropist_spell(controller):
+    controller.add_heroic_skill(HeroicSkill(name=HeroicSkillName.comet))
+    spells = controller.character.spells[ClassName.entropist]
+    assert any(s.name == "comet" for s in spells)
+
+
+def test_add_heroic_skill_hope_grants_spiritist_spell(controller):
+    controller.add_heroic_skill(HeroicSkill(name=HeroicSkillName.hope))
+    spells = controller.character.spells[ClassName.spiritist]
+    assert any(s.name == "hope" for s in spells)
+
+
+def test_add_heroic_skill_volcano_grants_elementalist_spell(controller):
+    controller.add_heroic_skill(HeroicSkill(name=HeroicSkillName.volcano))
+    spells = controller.character.spells[ClassName.elementalist]
+    assert any(s.name == "volcano" for s in spells)
+
+
+def test_add_heroic_skill_without_spell_effect_is_a_no_op(controller):
+    controller.add_heroic_skill(HeroicSkill(name=HeroicSkillName.deep_pockets))
+    assert controller.character.heroic_skills[-1].name == HeroicSkillName.deep_pockets
+    assert controller.character.spells == {}
+
+
+# --- apply_quality_effects ---
+
+def test_apply_quality_effects_amulet(controller):
+    item = Accessory(name="ring")
+    controller.apply_quality_effects(item, Quality(name="amulet"))
+    assert item.bonus_magic_defense == 1
+    assert item.bonus_defense == 0
+
+
+def test_apply_quality_effects_bulwark(controller):
+    item = Accessory(name="ring")
+    controller.apply_quality_effects(item, Quality(name="bulwark"))
+    assert item.bonus_defense == 1
+
+
+def test_apply_quality_effects_omnishield(controller):
+    item = Accessory(name="ring")
+    controller.apply_quality_effects(item, Quality(name="omnishield"))
+    assert item.bonus_defense == 1
+    assert item.bonus_magic_defense == 1
+
+
+def test_apply_quality_effects_initiative_up(controller):
+    item = Accessory(name="ring")
+    controller.apply_quality_effects(item, Quality(name="initiative_up"))
+    assert item.bonus_initiative == 4
+
+
+def test_apply_quality_effects_unknown_quality_is_a_no_op(controller):
+    item = Accessory(name="ring")
+    controller.apply_quality_effects(item, Quality(name="not_a_real_quality"))
+    assert item.bonus_defense == 0
+    assert item.bonus_magic_defense == 0
+    assert item.bonus_initiative == 0

--- a/tests/test_controller_resources.py
+++ b/tests/test_controller_resources.py
@@ -1,0 +1,75 @@
+from data.models import CharClass, HeroicSkill, HeroicSkillName
+
+
+def test_max_hp_base_formula(controller):
+    controller.character.level = 5
+    controller.character.might.base = 8
+    assert controller.max_hp() == 5 + 8 * 5
+
+
+def test_max_hp_includes_class_bonuses(controller):
+    controller.character.level = 5
+    controller.character.might.base = 8
+    controller.character.classes = [
+        CharClass(class_bonus="hp", bonus_value=5),
+        CharClass(class_bonus="hp", bonus_value=3),
+        CharClass(class_bonus="mp", bonus_value=100),  # should not count towards HP
+    ]
+    assert controller.max_hp() == 5 + 8 * 5 + 5 + 3
+
+
+def test_max_hp_extra_hp_heroic_skill_below_level_40(controller):
+    controller.character.level = 10
+    controller.character.might.base = 8
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.extra_hp)]
+    assert controller.max_hp() == 10 + 8 * 5 + 10
+
+
+def test_max_hp_extra_hp_heroic_skill_at_level_40(controller):
+    controller.character.level = 40
+    controller.character.might.base = 8
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.extra_hp)]
+    assert controller.max_hp() == 40 + 8 * 5 + 20
+
+
+def test_max_mp_base_formula_and_bonuses(controller):
+    controller.character.level = 5
+    controller.character.willpower.base = 9
+    controller.character.classes = [CharClass(class_bonus="mp", bonus_value=4)]
+    assert controller.max_mp() == 5 + 9 * 5 + 4
+
+
+def test_max_mp_extra_mp_heroic_skill(controller):
+    controller.character.level = 40
+    controller.character.willpower.base = 8
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.extra_mp)]
+    assert controller.max_mp() == 40 + 8 * 5 + 20
+
+
+def test_max_ip_base_and_bonuses(controller):
+    controller.character.classes = [CharClass(class_bonus="ip", bonus_value=2)]
+    assert controller.max_ip() == 6 + 2
+
+
+def test_max_ip_extra_ip_heroic_skill(controller):
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.extra_ip)]
+    assert controller.max_ip() == 6 + 4
+
+
+def test_current_pools_subtract_state_deltas(controller):
+    controller.character.level = 5
+    controller.character.might.base = 8
+    controller.character.willpower.base = 8
+    controller.state.minus_hp = 10
+    controller.state.minus_mp = 5
+    controller.state.minus_ip = 1
+    assert controller.current_hp() == controller.max_hp() - 10
+    assert controller.current_mp() == controller.max_mp() - 5
+    assert controller.current_ip() == controller.max_ip() - 1
+
+
+def test_crisis_value_is_floor_half_max_hp(controller):
+    controller.character.level = 5
+    controller.character.might.base = 8
+    assert controller.max_hp() == 45
+    assert controller.crisis_value() == 22

--- a/tests/test_controller_resting.py
+++ b/tests/test_controller_resting.py
@@ -1,0 +1,71 @@
+from data.models import HeroicSkill, HeroicSkillName
+
+
+def setup_pools(controller, level=5, might=8, willpower=8):
+    controller.character.level = level
+    controller.character.might.base = might
+    controller.character.willpower.base = willpower
+
+
+def test_use_health_potion_restores_hp_and_costs_ip(controller):
+    setup_pools(controller)
+    controller.state.minus_hp = 40
+    controller.use_health_potion()
+    assert controller.state.minus_hp == 0  # max(0, 40 - 50)
+    assert controller.state.minus_ip == 3
+
+
+def test_use_health_potion_ip_cost_reduced_by_deep_pockets(controller):
+    setup_pools(controller)
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.deep_pockets)]
+    controller.state.minus_hp = 40
+    controller.use_health_potion()
+    assert controller.state.minus_ip == 2
+
+
+def test_use_mana_potion_restores_mp_and_costs_ip(controller):
+    setup_pools(controller)
+    controller.state.minus_mp = 40
+    controller.use_mana_potion()
+    assert controller.state.minus_mp == 0
+    assert controller.state.minus_ip == 3
+
+
+def test_use_magic_tent_restores_hp_and_mp_fully(controller):
+    setup_pools(controller)
+    controller.state.minus_hp = 999
+    controller.state.minus_mp = 999
+    controller.use_magic_tent()
+    assert controller.state.minus_hp == 0
+    assert controller.state.minus_mp == 0
+    assert controller.state.minus_ip == 4
+
+
+def test_use_magic_tent_ip_cost_reduced_by_deep_pockets(controller):
+    setup_pools(controller)
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.deep_pockets)]
+    controller.use_magic_tent()
+    assert controller.state.minus_ip == 3
+
+
+def test_can_use_potion_gated_on_current_ip(controller):
+    setup_pools(controller)  # max_ip = 6
+    controller.state.minus_ip = 4  # current_ip = 2, cost 3
+    assert controller.can_use_potion() is False
+    controller.state.minus_ip = 3  # current_ip = 3, cost 3
+    assert controller.can_use_potion() is True
+
+
+def test_can_use_potion_with_deep_pockets_lower_cost(controller):
+    setup_pools(controller)
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.deep_pockets)]
+    controller.state.minus_ip = 4  # current_ip = 2, cost 2
+    assert controller.can_use_potion() is True
+
+
+def test_can_use_magic_tent_gated_on_current_ip(controller):
+    setup_pools(controller)  # max_ip = 6
+    controller.state.minus_ip = 3  # current_ip = 3, cost 4
+    assert controller.can_use_magic_tent() is False
+    controller.state.minus_ip = 2  # current_ip = 4, cost 4
+    assert controller.can_use_magic_tent() is True

--- a/tests/test_controller_spells.py
+++ b/tests/test_controller_spells.py
@@ -1,0 +1,49 @@
+from data.models import CharClass, ClassName, HeroicSkill, HeroicSkillName, Skill, Spell
+
+
+def test_add_spell_appends_and_dedups(controller):
+    spell = Spell(name="fireball", mp_cost=10)
+    controller.add_spell(spell, ClassName.elementalist)
+    controller.add_spell(spell, ClassName.elementalist)
+    assert controller.character.spells[ClassName.elementalist] == [spell]
+
+
+def test_remove_spell_removes_if_present(controller):
+    spell = Spell(name="fireball", mp_cost=10)
+    controller.add_spell(spell, ClassName.elementalist)
+    controller.remove_spell(spell, ClassName.elementalist)
+    assert controller.character.spells[ClassName.elementalist] == []
+
+
+def test_remove_spell_missing_is_a_no_op(controller):
+    spell = Spell(name="fireball", mp_cost=10)
+    controller.remove_spell(spell, ClassName.elementalist)  # should not raise
+    assert controller.character.spells.get(ClassName.elementalist, []) == []
+
+
+def test_can_add_spell_requires_class_and_casting_skill(controller):
+    assert controller.can_add_spell(ClassName.elementalist) is False
+
+    controller.character.classes = [CharClass(name=ClassName.elementalist, skills=[])]
+    assert controller.can_add_spell(ClassName.elementalist) is False
+
+    casting_skill = Skill(name="elemental_magic", current_level=2, max_level=10, can_add_spell=True)
+    controller.character.classes = [CharClass(name=ClassName.elementalist, skills=[casting_skill])]
+    assert controller.can_add_spell(ClassName.elementalist) is True
+
+    controller.character.spells[ClassName.elementalist] = [
+        Spell(name="a", mp_cost=5), Spell(name="b", mp_cost=5)
+    ]
+    assert controller.can_add_spell(ClassName.elementalist) is False
+
+
+def test_chimerist_max_spells(controller):
+    assert controller.chimerist_max_spells() == 2  # no spell_mimic skill: 0 + 2
+
+    controller.character.classes = [
+        CharClass(name=ClassName.chimerist, skills=[Skill(name="spell_mimic", current_level=3, max_level=10)])
+    ]
+    assert controller.chimerist_max_spells() == 5
+
+    controller.character.heroic_skills = [HeroicSkill(name=HeroicSkillName.chimeric_mastery)]
+    assert controller.chimerist_max_spells() == 7

--- a/tests/test_controller_status.py
+++ b/tests/test_controller_status.py
@@ -1,0 +1,56 @@
+import pytest
+
+from data.models import AttributeName, Status, Therioform
+
+
+@pytest.mark.parametrize("status,attribute,expected", [
+    (Status.dazed, "insight", 6),
+    (Status.enraged, "insight", 6),
+    (Status.enraged, "dexterity", 6),
+    (Status.poisoned, "might", 6),
+    (Status.poisoned, "willpower", 6),
+    (Status.shaken, "willpower", 6),
+    (Status.slow, "dexterity", 6),
+    (Status.weak, "might", 6),
+])
+def test_apply_status_single_status_modifier(controller, status, attribute, expected):
+    controller.state.statuses = [status]
+    controller.apply_status()
+    assert getattr(controller.character, attribute).current == expected
+
+
+def test_apply_status_improved_attribute_adds_bonus(controller):
+    controller.state.improved_attributes = [AttributeName.might]
+    controller.apply_status()
+    assert controller.character.might.current == 10
+
+
+@pytest.mark.parametrize("therioform_name,attribute", [
+    ("arpaktida", "insight"),
+    ("dynamotheria", "might"),
+    ("tachytheria", "dexterity"),
+])
+def test_apply_status_active_therioform_bonus(controller, therioform_name, attribute):
+    controller.state.active_therioforms = [Therioform(name=therioform_name)]
+    controller.apply_status()
+    assert getattr(controller.character, attribute).current == 10
+
+
+def test_apply_status_clamps_at_minimum(controller):
+    controller.state.statuses = [Status.enraged, Status.slow]  # dexterity -2 twice
+    controller.apply_status()
+    assert controller.character.dexterity.current == 6
+
+
+def test_apply_status_clamps_at_maximum(controller):
+    controller.character.might.base = 12
+    controller.state.improved_attributes = [AttributeName.might]
+    controller.apply_status()
+    assert controller.character.might.current == 12
+
+
+def test_apply_status_with_nothing_active_resets_to_base(controller):
+    controller.character.willpower.base = 8
+    controller.character.willpower.current = 2
+    controller.apply_status()
+    assert controller.character.willpower.current == 8

--- a/tests/test_controller_therioforms.py
+++ b/tests/test_controller_therioforms.py
@@ -1,0 +1,63 @@
+import math
+
+from data.models import CharClass, ClassName, Skill, Therioform
+
+
+def test_can_add_therioform_gated_by_theriomorphosis_skill_level(controller):
+    controller.character.special.therioforms = [Therioform(name="a")]
+    controller.character.classes = [
+        CharClass(name=ClassName.mutant, skills=[Skill(name="theriomorphosis", current_level=1, max_level=10)])
+    ]
+    assert controller.can_add_therioform() is False  # already has 1, level allows 1
+
+    controller.character.classes = [
+        CharClass(name=ClassName.mutant, skills=[Skill(name="theriomorphosis", current_level=2, max_level=10)])
+    ]
+    assert controller.can_add_therioform() is True
+
+
+def test_available_therioforms_for_theriomorphosis_returns_learned_ones(controller):
+    learned = [Therioform(name="a"), Therioform(name="b")]
+    controller.character.special.therioforms = learned
+    assert controller.available_therioforms_for_skill("theriomorphosis") == learned
+
+
+def test_available_therioforms_for_genoclepsis_returns_compendium_therioforms(controller, monkeypatch):
+    import types
+    fake_compendium = types.SimpleNamespace(therioforms=[Therioform(name="all_a"), Therioform(name="all_b")])
+    monkeypatch.setattr("data.compendium.COMPENDIUM", fake_compendium)
+    result = controller.available_therioforms_for_skill("genoclepsis")
+    assert [t.name for t in result] == ["all_a", "all_b"]
+
+
+def test_available_therioforms_unknown_skill_returns_empty(controller):
+    assert controller.available_therioforms_for_skill("unrelated_skill") == []
+
+
+def test_max_manifest_therioforms(controller):
+    assert controller.max_manifest_therioforms("theriomorphosis") == 2
+
+    controller.character.classes = [
+        CharClass(name=ClassName.mutant, skills=[Skill(name="genoclepsis", current_level=3, max_level=10)])
+    ]
+    assert controller.max_manifest_therioforms("genoclepsis") == 3
+    assert controller.max_manifest_therioforms("unrelated_skill") == 0
+
+
+def test_can_manifest_therioform_requires_at_least_3_hp(controller):
+    controller.character.level = 5
+    controller.character.might.base = 8  # max_hp = 45
+    controller.state.minus_hp = 44  # current_hp = 1
+    assert controller.can_manifest_therioform() is False
+    controller.state.minus_hp = 42  # current_hp = 3
+    assert controller.can_manifest_therioform() is True
+
+
+def test_apply_manifest_therioform_costs_a_third_of_current_hp(controller):
+    controller.character.level = 5
+    controller.character.might.base = 8  # max_hp = 45
+    assert controller.current_hp() == 45
+    therioforms = [Therioform(name="chosen")]
+    controller.apply_manifest_therioform(therioforms)
+    assert controller.state.minus_hp == math.floor(45 / 3)
+    assert controller.state.active_therioforms == therioforms

--- a/tests/test_localizator.py
+++ b/tests/test_localizator.py
@@ -10,8 +10,8 @@ def test_init_localizator_loads_translations(streamlit_stub, tmp_path):
     ru_dir = tmp_path / 'ru'
     en_dir.mkdir()
     ru_dir.mkdir()
-    (en_dir / 'base.yaml').write_text('{"error_name_empty": "Name should not be empty.", "bond_explanation": "About Bonds"}')
-    (ru_dir / 'base.yaml').write_text('{"error_name_empty": "Имя не должно быть пустым."}')
+    (en_dir / 'base.yaml').write_text('{"error_name_empty": "Name should not be empty.", "bond_explanation": "About Bonds"}', encoding='utf-8')
+    (ru_dir / 'base.yaml').write_text('{"error_name_empty": "Имя не должно быть пустым."}', encoding='utf-8')
     init_localizator(tmp_path)
     localizator = streamlit_stub.session_state['localizator']
     en = localizator.get(LangEnum.en)

--- a/tests/test_localizator.py
+++ b/tests/test_localizator.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 import pytest
 
-from fabula_charsheet.data.localizator import init_localizator
-from fabula_charsheet.data.models import LangEnum
+from data.localizator import init_localizator
+from data.models import LangEnum
 
 
 def test_init_localizator_loads_translations(streamlit_stub, tmp_path):

--- a/tests/test_saved_characters.py
+++ b/tests/test_saved_characters.py
@@ -1,4 +1,4 @@
-from fabula_charsheet.data import saved_characters
+from data import saved_characters
 
 
 def test_saved_characters_init(tmp_path):


### PR DESCRIPTION
  Adds CI-backed test coverage for `CharacterController`, the app's core game-logic hub, which previously had zero tests. Along the way, fixes a real equip/unequip bug and a couple of pre-existing issues  in the test suite itself.
  
  **Bug fixes**

  - `CharacterController.remove_item` unequipped items using the wrong slot names ("weapon", "shield") instead of Equipped's actual fields (main_hand, off_hand). As a result, removing an equipped weapon or shield from the backpack silently failed to unequip it. Now checks all four real slots directly.
  - tests/conftest.py: the `assets_dir` fixture never created a `qualities/` directory, which `compendium.init()` requires — this broke every test relying on that fixture.
  - tests/test_localizator.py: a fixture wrote Cyrillic text via `write_text()` without `encoding='utf-8'`, which fails on Windows' default codec.

  **Test infrastructure**

  - Dropped the hand-rolled `pydantic / yaml / annotated_types` stubs from conftest.py in favor of the real libraries. The stub evaluated `Field(default_factory=...)` once at class-definition time instead of per-instance, so every `Character()` (and other model) instance silently shared the same mutable Dexterity/Inventory/list defaults — invisible under the old loose stub, but a correctness trap for tests that build multiple independent characters.
  - Fixed a latent dual-module-identity bug this surfaced: test files imported models via `fabula_charsheet.data...` while all app code imports the same modules via the short `data...` path. With both on `sys.path`, this created two distinct copies of every model class, which real pydantic's isinstance checks reject. All test imports now use the same short `data.*` path the app itself uses.
  - Added `.github/workflows/test.yml` to run `uv run pytest` on PRs into main/master.

  **New tests**

  Ten new files covering `CharacterController` end to end (133 new tests, 141 total)